### PR TITLE
handle genesis state root hash

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1607,8 +1607,9 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
     } else if (OP_SEPOLIA.equals(network) || OP_MAINNET.equals(network)) {
       effectiveGenesisFile = OpGenesisConfigFile.fromResource(network.getGenesisFile());
     } else {
-      effectiveGenesisFile = GenesisConfigFile.fromResource(
-          Optional.ofNullable(network).orElse(MAINNET).getGenesisFile());
+      effectiveGenesisFile =
+          GenesisConfigFile.fromResource(
+              Optional.ofNullable(network).orElse(MAINNET).getGenesisFile());
     }
     return effectiveGenesisFile.withOverrides(genesisConfigOverrides);
   }

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -22,6 +22,8 @@ import static java.util.Collections.singletonList;
 import static org.hyperledger.besu.cli.DefaultCommandValues.getDefaultBesuDataPath;
 import static org.hyperledger.besu.cli.config.NetworkName.EPHEMERY;
 import static org.hyperledger.besu.cli.config.NetworkName.MAINNET;
+import static org.hyperledger.besu.cli.config.NetworkName.OP_MAINNET;
+import static org.hyperledger.besu.cli.config.NetworkName.OP_SEPOLIA;
 import static org.hyperledger.besu.cli.util.CommandLineUtils.DEPENDENCY_WARNING_MSG;
 import static org.hyperledger.besu.cli.util.CommandLineUtils.isOptionSet;
 import static org.hyperledger.besu.controller.BesuController.DATABASE_PATH;
@@ -88,6 +90,7 @@ import org.hyperledger.besu.config.CheckpointConfigOptions;
 import org.hyperledger.besu.config.GenesisConfigFile;
 import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.config.MergeConfiguration;
+import org.hyperledger.besu.config.OpGenesisConfigFile;
 import org.hyperledger.besu.controller.BesuController;
 import org.hyperledger.besu.controller.BesuControllerBuilder;
 import org.hyperledger.besu.crypto.Blake2bfMessageDigest;
@@ -1597,13 +1600,16 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
 
   private GenesisConfigFile readGenesisConfigFile() {
     GenesisConfigFile effectiveGenesisFile;
-    effectiveGenesisFile =
-        network.equals(EPHEMERY)
-            ? EphemeryGenesisUpdater.updateGenesis(genesisConfigOverrides)
-            : genesisFile != null
-                ? GenesisConfigFile.fromSource(genesisConfigSource(genesisFile))
-                : GenesisConfigFile.fromResource(
-                    Optional.ofNullable(network).orElse(MAINNET).getGenesisFile());
+    if (EPHEMERY.equals(network)) {
+      effectiveGenesisFile = EphemeryGenesisUpdater.updateGenesis(genesisConfigOverrides);
+    } else if (genesisFile != null) {
+      effectiveGenesisFile = GenesisConfigFile.fromSource(genesisConfigSource(genesisFile));
+    } else if (OP_SEPOLIA.equals(network) || OP_MAINNET.equals(network)) {
+      effectiveGenesisFile = OpGenesisConfigFile.fromResource(network.getGenesisFile());
+    } else {
+      effectiveGenesisFile = GenesisConfigFile.fromResource(
+          Optional.ofNullable(network).orElse(MAINNET).getGenesisFile());
+    }
     return effectiveGenesisFile.withOverrides(genesisConfigOverrides);
   }
 

--- a/besu/src/main/java/org/hyperledger/besu/cli/config/NetworkName.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/config/NetworkName.java
@@ -46,7 +46,12 @@ public enum NetworkName {
   /** Classic network name. */
   CLASSIC("/classic.json", BigInteger.valueOf(1)),
   /** Mordor network name. */
-  MORDOR("/mordor.json", BigInteger.valueOf(7));
+  MORDOR("/mordor.json", BigInteger.valueOf(7)),
+
+  /** Optimism Mainnet network name. */
+  OP_MAINNET("/optimism-mainnet.json", BigInteger.valueOf(10L)),
+  /** Optimism sepolia network name. */
+  OP_SEPOLIA("/optimism-sepolia.json", BigInteger.valueOf(11155420L));
 
   private final String genesisFile;
   private final BigInteger networkId;

--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuController.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuController.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.controller;
 import org.hyperledger.besu.cli.config.EthNetworkConfig;
 import org.hyperledger.besu.config.GenesisConfigFile;
 import org.hyperledger.besu.config.GenesisConfigOptions;
+import org.hyperledger.besu.config.OpGenesisConfigFile;
 import org.hyperledger.besu.config.PowAlgorithm;
 import org.hyperledger.besu.config.QbftConfigOptions;
 import org.hyperledger.besu.cryptoservices.NodeKey;
@@ -365,6 +366,9 @@ public class BesuController implements java.io.Closeable {
         builder = new QbftBesuControllerBuilder();
       } else if (configOptions.isClique()) {
         builder = new CliqueBesuControllerBuilder();
+      } else if (genesisConfigFile instanceof OpGenesisConfigFile) {
+        // todo Temporary modification, will later use OptimismBesuControllerBuilder
+        builder = new MainnetBesuControllerBuilder();
       } else {
         throw new IllegalArgumentException("Unknown consensus mechanism defined");
       }

--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -845,7 +845,8 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
             () -> {
               if (genesisConfigFile instanceof OpGenesisConfigFile opGenesisConfigFile) {
                 // todo Temporary modification
-                return OptimismGenesisState.fromConfig(dataStorageConfiguration, opGenesisConfigFile, protocolSchedule);
+                return OptimismGenesisState.fromConfig(
+                    dataStorageConfiguration, opGenesisConfigFile, protocolSchedule);
               } else {
                 return GenesisState.fromConfig(
                     dataStorageConfiguration, genesisConfigFile, protocolSchedule);

--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -20,6 +20,7 @@ import org.hyperledger.besu.components.BesuComponent;
 import org.hyperledger.besu.config.CheckpointConfigOptions;
 import org.hyperledger.besu.config.GenesisConfigFile;
 import org.hyperledger.besu.config.GenesisConfigOptions;
+import org.hyperledger.besu.config.OpGenesisConfigFile;
 import org.hyperledger.besu.consensus.merge.MergeContext;
 import org.hyperledger.besu.consensus.merge.UnverifiedForkchoiceSupplier;
 import org.hyperledger.besu.consensus.qbft.BFTPivotSelectorFromPeers;
@@ -40,6 +41,7 @@ import org.hyperledger.besu.ethereum.chain.ChainPrunerConfiguration;
 import org.hyperledger.besu.ethereum.chain.DefaultBlockchain;
 import org.hyperledger.besu.ethereum.chain.GenesisState;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
+import org.hyperledger.besu.ethereum.chain.OptimismGenesisState;
 import org.hyperledger.besu.ethereum.chain.VariablesStorage;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Difficulty;
@@ -840,9 +842,15 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
             genesisStateRoot ->
                 GenesisState.fromStorage(genesisStateRoot, genesisConfigFile, protocolSchedule))
         .orElseGet(
-            () ->
-                GenesisState.fromConfig(
-                    dataStorageConfiguration, genesisConfigFile, protocolSchedule));
+            () -> {
+              if (genesisConfigFile instanceof OpGenesisConfigFile opGenesisConfigFile) {
+                // todo Temporary modification
+                return OptimismGenesisState.fromConfig(dataStorageConfiguration, opGenesisConfigFile, protocolSchedule);
+              } else {
+                return GenesisState.fromConfig(
+                    dataStorageConfiguration, genesisConfigFile, protocolSchedule);
+              }
+            });
   }
 
   private TrieLogPruner createTrieLogPruner(

--- a/config/src/main/java/org/hyperledger/besu/config/GenesisConfigFile.java
+++ b/config/src/main/java/org/hyperledger/besu/config/GenesisConfigFile.java
@@ -38,11 +38,11 @@ public class GenesisConfigFile {
   /** The constant BASEFEE_AT_GENESIS_DEFAULT_VALUE. */
   public static final Wei BASEFEE_AT_GENESIS_DEFAULT_VALUE = Wei.of(1_000_000_000L);
 
-  private final GenesisReader loader;
-  private final ObjectNode genesisRoot;
-  private Map<String, String> overrides;
+  final GenesisReader loader;
+  protected final ObjectNode genesisRoot;
+  protected Map<String, String> overrides;
 
-  private GenesisConfigFile(final GenesisReader loader) {
+  GenesisConfigFile(final GenesisReader loader) {
     this.loader = loader;
     this.genesisRoot = loader.getRoot();
   }

--- a/config/src/main/java/org/hyperledger/besu/config/GenesisConfigFile.java
+++ b/config/src/main/java/org/hyperledger/besu/config/GenesisConfigFile.java
@@ -39,8 +39,10 @@ public class GenesisConfigFile {
   public static final Wei BASEFEE_AT_GENESIS_DEFAULT_VALUE = Wei.of(1_000_000_000L);
 
   final GenesisReader loader;
+
   /** genesis root node */
   protected final ObjectNode genesisRoot;
+
   /** map of genesis overrides */
   protected Map<String, String> overrides;
 

--- a/config/src/main/java/org/hyperledger/besu/config/GenesisConfigFile.java
+++ b/config/src/main/java/org/hyperledger/besu/config/GenesisConfigFile.java
@@ -39,7 +39,9 @@ public class GenesisConfigFile {
   public static final Wei BASEFEE_AT_GENESIS_DEFAULT_VALUE = Wei.of(1_000_000_000L);
 
   final GenesisReader loader;
+  /** genesis root node */
   protected final ObjectNode genesisRoot;
+  /** map of genesis overrides */
   protected Map<String, String> overrides;
 
   GenesisConfigFile(final GenesisReader loader) {

--- a/config/src/main/java/org/hyperledger/besu/config/JsonGenesisConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/JsonGenesisConfigOptions.java
@@ -65,7 +65,7 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
    * @param configRoot the config root
    * @return the json genesis config options
    */
-  public static JsonOptimismConfigOptions fromJsonObject(final ObjectNode configRoot) {
+  public static JsonOptimismGenesisConfigOptions fromJsonObject(final ObjectNode configRoot) {
     return fromJsonObjectWithOverrides(configRoot, emptyMap());
   }
 
@@ -76,11 +76,11 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
    * @param configOverrides the config overrides
    * @return the json genesis config options
    */
-  static JsonOptimismConfigOptions fromJsonObjectWithOverrides(
+  static JsonOptimismGenesisConfigOptions fromJsonObjectWithOverrides(
       final ObjectNode configRoot, final Map<String, String> configOverrides) {
     final TransitionsConfigOptions transitionsConfigOptions;
     transitionsConfigOptions = loadTransitionsFrom(configRoot);
-    return new JsonOptimismConfigOptions(configRoot, configOverrides, transitionsConfigOptions);
+    return new JsonOptimismGenesisConfigOptions(configRoot, configOverrides, transitionsConfigOptions);
   }
 
   private static TransitionsConfigOptions loadTransitionsFrom(final ObjectNode parentNode) {
@@ -540,7 +540,7 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
     return builder.build();
   }
 
-  private OptionalLong getOptionalLong(final String key) {
+  protected OptionalLong getOptionalLong(final String key) {
     if (configOverrides.containsKey(key)) {
       final String value = configOverrides.get(key);
       return value == null || value.isEmpty()
@@ -551,7 +551,7 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
     }
   }
 
-  private OptionalInt getOptionalInt(final String key) {
+  protected OptionalInt getOptionalInt(final String key) {
     if (configOverrides.containsKey(key)) {
       final String value = configOverrides.get(key);
       return value == null || value.isEmpty()
@@ -562,7 +562,7 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
     }
   }
 
-  private Optional<BigInteger> getOptionalBigInteger(final String key) {
+  protected Optional<BigInteger> getOptionalBigInteger(final String key) {
     if (configOverrides.containsKey(key)) {
       final String value = configOverrides.get(key);
       return value == null || value.isEmpty()
@@ -573,7 +573,7 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
     }
   }
 
-  private Optional<Boolean> getOptionalBoolean(final String key) {
+  protected Optional<Boolean> getOptionalBoolean(final String key) {
     if (configOverrides.containsKey(key)) {
       final String value = configOverrides.get(key);
       return value == null || value.isEmpty()
@@ -584,7 +584,7 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
     }
   }
 
-  private Optional<Hash> getOptionalHash(final String key) {
+  protected Optional<Hash> getOptionalHash(final String key) {
     if (configOverrides.containsKey(key)) {
       final String overrideHash = configOverrides.get(key);
       return Optional.of(Hash.fromHexString(overrideHash));

--- a/config/src/main/java/org/hyperledger/besu/config/JsonGenesisConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/JsonGenesisConfigOptions.java
@@ -56,7 +56,8 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
       "consolidationrequestcontractaddress";
 
   protected final ObjectNode configRoot;
-  protected final Map<String, String> configOverrides = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+  protected final Map<String, String> configOverrides =
+      new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
   protected final TransitionsConfigOptions transitions;
 
   /**
@@ -80,7 +81,8 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
       final ObjectNode configRoot, final Map<String, String> configOverrides) {
     final TransitionsConfigOptions transitionsConfigOptions;
     transitionsConfigOptions = loadTransitionsFrom(configRoot);
-    return new JsonOptimismGenesisConfigOptions(configRoot, configOverrides, transitionsConfigOptions);
+    return new JsonOptimismGenesisConfigOptions(
+        configRoot, configOverrides, transitionsConfigOptions);
   }
 
   private static TransitionsConfigOptions loadTransitionsFrom(final ObjectNode parentNode) {

--- a/config/src/main/java/org/hyperledger/besu/config/JsonGenesisConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/JsonGenesisConfigOptions.java
@@ -55,9 +55,12 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
   private static final String CONSOLIDATION_REQUEST_CONTRACT_ADDRESS_KEY =
       "consolidationrequestcontractaddress";
 
+  /** root node. */
   protected final ObjectNode configRoot;
+  /** genesis config override map. */
   protected final Map<String, String> configOverrides =
       new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+  /** transitions config options. */
   protected final TransitionsConfigOptions transitions;
 
   /**
@@ -542,6 +545,12 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
     return builder.build();
   }
 
+  /**
+   * Gets optional long value from config, deferring to overrides if they are present.
+   * @param key string to lookup the value for.
+   *
+   * @return OptionalLong value, empty if not present.
+   */
   protected OptionalLong getOptionalLong(final String key) {
     if (configOverrides.containsKey(key)) {
       final String value = configOverrides.get(key);
@@ -553,6 +562,12 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
     }
   }
 
+  /**
+   * Gets an optional int value from config, by key name.
+   *
+   * @param key string to fetch the value by.
+   * @return OptionalInt value.
+   */
   protected OptionalInt getOptionalInt(final String key) {
     if (configOverrides.containsKey(key)) {
       final String value = configOverrides.get(key);
@@ -564,6 +579,12 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
     }
   }
 
+  /**
+   * Gets an optional BigInteger value from config, by key name.
+   *
+   * @param key string key to fetch the value by.
+   * @return Optional BigInteger value.
+   */
   protected Optional<BigInteger> getOptionalBigInteger(final String key) {
     if (configOverrides.containsKey(key)) {
       final String value = configOverrides.get(key);
@@ -575,6 +596,12 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
     }
   }
 
+  /**
+   * Gets an optional boolean value from config, by key name.
+   *
+   * @param key string to fetch the value by.
+   * @return Optional bolean value.
+   */
   protected Optional<Boolean> getOptionalBoolean(final String key) {
     if (configOverrides.containsKey(key)) {
       final String value = configOverrides.get(key);
@@ -586,6 +613,12 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
     }
   }
 
+  /**
+   * Gets an optional Hash value from config, by key name.
+   *
+   * @param key string to fetch the value by.
+   * @return Optional Hash value.
+   */
   protected Optional<Hash> getOptionalHash(final String key) {
     if (configOverrides.containsKey(key)) {
       final String overrideHash = configOverrides.get(key);

--- a/config/src/main/java/org/hyperledger/besu/config/JsonGenesisConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/JsonGenesisConfigOptions.java
@@ -55,9 +55,9 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
   private static final String CONSOLIDATION_REQUEST_CONTRACT_ADDRESS_KEY =
       "consolidationrequestcontractaddress";
 
-  private final ObjectNode configRoot;
-  private final Map<String, String> configOverrides = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-  private final TransitionsConfigOptions transitions;
+  protected final ObjectNode configRoot;
+  protected final Map<String, String> configOverrides = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+  protected final TransitionsConfigOptions transitions;
 
   /**
    * From json object json genesis config options.
@@ -65,7 +65,7 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
    * @param configRoot the config root
    * @return the json genesis config options
    */
-  public static JsonGenesisConfigOptions fromJsonObject(final ObjectNode configRoot) {
+  public static JsonOptimismConfigOptions fromJsonObject(final ObjectNode configRoot) {
     return fromJsonObjectWithOverrides(configRoot, emptyMap());
   }
 
@@ -76,11 +76,11 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
    * @param configOverrides the config overrides
    * @return the json genesis config options
    */
-  static JsonGenesisConfigOptions fromJsonObjectWithOverrides(
+  static JsonOptimismConfigOptions fromJsonObjectWithOverrides(
       final ObjectNode configRoot, final Map<String, String> configOverrides) {
     final TransitionsConfigOptions transitionsConfigOptions;
     transitionsConfigOptions = loadTransitionsFrom(configRoot);
-    return new JsonGenesisConfigOptions(configRoot, configOverrides, transitionsConfigOptions);
+    return new JsonOptimismConfigOptions(configRoot, configOverrides, transitionsConfigOptions);
   }
 
   private static TransitionsConfigOptions loadTransitionsFrom(final ObjectNode parentNode) {

--- a/config/src/main/java/org/hyperledger/besu/config/JsonGenesisConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/JsonGenesisConfigOptions.java
@@ -57,9 +57,11 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
 
   /** root node. */
   protected final ObjectNode configRoot;
+
   /** genesis config override map. */
   protected final Map<String, String> configOverrides =
       new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+
   /** transitions config options. */
   protected final TransitionsConfigOptions transitions;
 
@@ -547,8 +549,8 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
 
   /**
    * Gets optional long value from config, deferring to overrides if they are present.
-   * @param key string to lookup the value for.
    *
+   * @param key string to lookup the value for.
    * @return OptionalLong value, empty if not present.
    */
   protected OptionalLong getOptionalLong(final String key) {

--- a/config/src/main/java/org/hyperledger/besu/config/JsonOptimismConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/JsonOptimismConfigOptions.java
@@ -1,0 +1,162 @@
+package org.hyperledger.besu.config;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import static java.util.Objects.isNull;
+
+public class JsonOptimismConfigOptions extends JsonGenesisConfigOptions implements OptimismConfigOptions {
+  /** The constant DEFAULT. */
+  public static final OptimismConfigOptions DEFAULT =
+      new JsonOptimismConfigOptions();
+
+  private static final String OPTIMISM_KEY = "optimism";
+
+  private final ObjectNode optimismConfigRoot;
+
+  /**
+   * Instantiates a new empty Optimism config options.
+   */
+  JsonOptimismConfigOptions() {
+    super(null, null, null);
+    this.optimismConfigRoot = JsonUtil.createEmptyObjectNode();
+  }
+
+  /**
+   * Instantiates a new Optimism config options.
+   *
+   * @param maybeConfig the optional config
+   * @param configOverrides the config overrides map
+   * @param transitionsConfig the transitions configuration
+   */
+  JsonOptimismConfigOptions(
+          final ObjectNode maybeConfig,
+          final Map<String, String> configOverrides,
+          final TransitionsConfigOptions transitionsConfig) {
+    super(maybeConfig, configOverrides, transitionsConfig);
+    Optional<ObjectNode> optionNode = JsonUtil.getObjectNode(maybeConfig, OPTIMISM_KEY);
+    this.optimismConfigRoot = optionNode.orElseGet(JsonUtil::createEmptyObjectNode);
+  }
+
+  /**
+   * Gets EIP1559 elasticity.
+   *
+   * @return the EIP1559 elasticity
+   */
+  public OptionalLong getEIP1559Elasticity() {
+    OptionalLong eip1559elasticity = JsonUtil.getLong(optimismConfigRoot, "eip1559elasticity");
+    return eip1559elasticity.isEmpty() ? OptionalLong.of(6L) : eip1559elasticity;
+  }
+
+  /**
+   * Gets EIP1559 denominator.
+   *
+   * @return the EIP1559 denominator
+   */
+  public OptionalLong getEIP1559Denominator() {
+    OptionalLong eip1559Denominator = JsonUtil.getLong(optimismConfigRoot, "eip1559denominator");
+    return eip1559Denominator.isEmpty() ? OptionalLong.of(50L) : eip1559Denominator;
+  }
+
+  /**
+   * Gets EIP1559 denominatorCanyon.
+   *
+   * @return the EIP1559 denominatorCanyon
+   */
+  public OptionalLong getEIP1559DenominatorCanyon() {
+    OptionalLong eip1559DenominatorCanyon =
+        JsonUtil.getLong(optimismConfigRoot, "eip1559denominatorcanyon");
+    return eip1559DenominatorCanyon.isEmpty() ? OptionalLong.of(250L) : eip1559DenominatorCanyon;
+  }
+
+  /**
+   * As map.
+   *
+   * @return the map
+   */
+  @Override
+  public Map<String, Object> asMap() {
+    final ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
+    getChainId().ifPresent(chainId -> builder.put("chainId", chainId));
+
+    // mainnet fork blocks
+    getHomesteadBlockNumber().ifPresent(l -> builder.put("homesteadBlock", l));
+    getDaoForkBlock().ifPresent(l -> builder.put("daoForkBlock", l));
+    getTangerineWhistleBlockNumber().ifPresent(l -> builder.put("eip150Block", l));
+    getSpuriousDragonBlockNumber().ifPresent(l -> builder.put("eip158Block", l));
+    getByzantiumBlockNumber().ifPresent(l -> builder.put("byzantiumBlock", l));
+    getConstantinopleBlockNumber().ifPresent(l -> builder.put("constantinopleBlock", l));
+    getPetersburgBlockNumber().ifPresent(l -> builder.put("petersburgBlock", l));
+    getIstanbulBlockNumber().ifPresent(l -> builder.put("istanbulBlock", l));
+    getMuirGlacierBlockNumber().ifPresent(l -> builder.put("muirGlacierBlock", l));
+    getBerlinBlockNumber().ifPresent(l -> builder.put("berlinBlock", l));
+    getLondonBlockNumber().ifPresent(l -> builder.put("londonBlock", l));
+    getArrowGlacierBlockNumber().ifPresent(l -> builder.put("arrowGlacierBlock", l));
+    getGrayGlacierBlockNumber().ifPresent(l -> builder.put("grayGlacierBlock", l));
+    getMergeNetSplitBlockNumber().ifPresent(l -> builder.put("mergeNetSplitBlock", l));
+    getShanghaiTime().ifPresent(l -> builder.put("shanghaiTime", l));
+    getCancunTime().ifPresent(l -> builder.put("cancunTime", l));
+    getCancunEOFTime().ifPresent(l -> builder.put("cancunEOFTime", l));
+    getPragueTime().ifPresent(l -> builder.put("pragueTime", l));
+    getOsakaTime().ifPresent(l -> builder.put("osakaTime", l));
+    getTerminalBlockNumber().ifPresent(l -> builder.put("terminalBlockNumber", l));
+    getTerminalBlockHash().ifPresent(h -> builder.put("terminalBlockHash", h.toHexString()));
+    getFutureEipsTime().ifPresent(l -> builder.put("futureEipsTime", l));
+    getExperimentalEipsTime().ifPresent(l -> builder.put("experimentalEipsTime", l));
+
+    // classic fork blocks
+    getClassicForkBlock().ifPresent(l -> builder.put("classicForkBlock", l));
+    getEcip1015BlockNumber().ifPresent(l -> builder.put("ecip1015Block", l));
+    getDieHardBlockNumber().ifPresent(l -> builder.put("dieHardBlock", l));
+    getGothamBlockNumber().ifPresent(l -> builder.put("gothamBlock", l));
+    getDefuseDifficultyBombBlockNumber().ifPresent(l -> builder.put("ecip1041Block", l));
+    getAtlantisBlockNumber().ifPresent(l -> builder.put("atlantisBlock", l));
+    getAghartaBlockNumber().ifPresent(l -> builder.put("aghartaBlock", l));
+    getPhoenixBlockNumber().ifPresent(l -> builder.put("phoenixBlock", l));
+    getThanosBlockNumber().ifPresent(l -> builder.put("thanosBlock", l));
+    getMagnetoBlockNumber().ifPresent(l -> builder.put("magnetoBlock", l));
+    getMystiqueBlockNumber().ifPresent(l -> builder.put("mystiqueBlock", l));
+    getSpiralBlockNumber().ifPresent(l -> builder.put("spiralBlock", l));
+
+    getContractSizeLimit().ifPresent(l -> builder.put("contractSizeLimit", l));
+    getEvmStackSize().ifPresent(l -> builder.put("evmstacksize", l));
+    getEcip1017EraRounds().ifPresent(l -> builder.put("ecip1017EraRounds", l));
+
+    getWithdrawalRequestContractAddress()
+            .ifPresent(l -> builder.put("withdrawalRequestContractAddress", l));
+    getDepositContractAddress().ifPresent(l -> builder.put("depositContractAddress", l));
+    getConsolidationRequestContractAddress()
+            .ifPresent(l -> builder.put("consolidationRequestContractAddress", l));
+
+    if (isClique()) {
+      builder.put("clique", getCliqueConfigOptions().asMap());
+    }
+    if (isEthHash()) {
+      builder.put("ethash", getEthashConfigOptions().asMap());
+    }
+    if (isIbft2()) {
+      builder.put("ibft2", getBftConfigOptions().asMap());
+    }
+    if (isQbft()) {
+      builder.put("qbft", getQbftConfigOptions().asMap());
+    }
+
+    if (isZeroBaseFee()) {
+      builder.put("zeroBaseFee", true);
+    }
+
+    if (isFixedBaseFee()) {
+      builder.put("fixedBaseFee", true);
+    }
+
+    getEIP1559Elasticity().ifPresent(l -> builder.put("eip1559Elasticity", l));
+    getEIP1559Denominator().ifPresent(l -> builder.put("eip1559Denominator", l));
+    getEIP1559DenominatorCanyon().ifPresent(l -> builder.put("eip1559DenominatorCanyon", l));
+    return builder.build();
+  }
+}

--- a/config/src/main/java/org/hyperledger/besu/config/JsonOptimismConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/JsonOptimismConfigOptions.java
@@ -1,10 +1,24 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.hyperledger.besu.config;
-
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
 import java.util.OptionalLong;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableMap;
 
 public class JsonOptimismConfigOptions implements OptimismConfigOptions {
 

--- a/config/src/main/java/org/hyperledger/besu/config/JsonOptimismConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/JsonOptimismConfigOptions.java
@@ -20,8 +20,10 @@ import java.util.OptionalLong;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 
+/** Json implementation of Optimism genesis config options. */
 public class JsonOptimismConfigOptions implements OptimismConfigOptions {
 
+  /** Default Json Optimism config options */
   public static final JsonOptimismConfigOptions DEFAULT =
       new JsonOptimismConfigOptions(JsonUtil.createEmptyObjectNode());
 

--- a/config/src/main/java/org/hyperledger/besu/config/JsonOptimismConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/JsonOptimismConfigOptions.java
@@ -1,46 +1,31 @@
 package org.hyperledger.besu.config;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.OptionalLong;
 
-import static java.util.Objects.isNull;
+public class JsonOptimismConfigOptions implements OptimismConfigOptions {
 
-public class JsonOptimismConfigOptions extends JsonGenesisConfigOptions implements OptimismConfigOptions {
-  /** The constant DEFAULT. */
-  public static final OptimismConfigOptions DEFAULT =
-      new JsonOptimismConfigOptions();
+  public static final JsonOptimismConfigOptions DEFAULT =
+      new JsonOptimismConfigOptions(JsonUtil.createEmptyObjectNode());
 
-  private static final String OPTIMISM_KEY = "optimism";
+  private static final String EIP1559_ELASTICITY = "eip1559elasticity";
+
+  private static final String EIP1559_DENOMINATOR = "eip1559denominator";
+
+  private static final String EIP1559_DENOMINATOR_CANYON = "eip1559denominatorcanyon";
 
   private final ObjectNode optimismConfigRoot;
 
   /**
-   * Instantiates a new empty Optimism config options.
-   */
-  JsonOptimismConfigOptions() {
-    super(null, null, null);
-    this.optimismConfigRoot = JsonUtil.createEmptyObjectNode();
-  }
-
-  /**
-   * Instantiates a new Optimism config options.
+   * Instantiates a new optimism options.
    *
-   * @param maybeConfig the optional config
-   * @param configOverrides the config overrides map
-   * @param transitionsConfig the transitions configuration
+   * @param optimismConfigRoot the optimism config root
    */
-  JsonOptimismConfigOptions(
-          final ObjectNode maybeConfig,
-          final Map<String, String> configOverrides,
-          final TransitionsConfigOptions transitionsConfig) {
-    super(maybeConfig, configOverrides, transitionsConfig);
-    Optional<ObjectNode> optionNode = JsonUtil.getObjectNode(maybeConfig, OPTIMISM_KEY);
-    this.optimismConfigRoot = optionNode.orElseGet(JsonUtil::createEmptyObjectNode);
+  public JsonOptimismConfigOptions(final ObjectNode optimismConfigRoot) {
+    this.optimismConfigRoot = optimismConfigRoot;
   }
 
   /**
@@ -48,8 +33,9 @@ public class JsonOptimismConfigOptions extends JsonGenesisConfigOptions implemen
    *
    * @return the EIP1559 elasticity
    */
+  @Override
   public OptionalLong getEIP1559Elasticity() {
-    OptionalLong eip1559elasticity = JsonUtil.getLong(optimismConfigRoot, "eip1559elasticity");
+    OptionalLong eip1559elasticity = JsonUtil.getLong(optimismConfigRoot, EIP1559_ELASTICITY);
     return eip1559elasticity.isEmpty() ? OptionalLong.of(6L) : eip1559elasticity;
   }
 
@@ -58,8 +44,9 @@ public class JsonOptimismConfigOptions extends JsonGenesisConfigOptions implemen
    *
    * @return the EIP1559 denominator
    */
+  @Override
   public OptionalLong getEIP1559Denominator() {
-    OptionalLong eip1559Denominator = JsonUtil.getLong(optimismConfigRoot, "eip1559denominator");
+    OptionalLong eip1559Denominator = JsonUtil.getLong(optimismConfigRoot, EIP1559_DENOMINATOR);
     return eip1559Denominator.isEmpty() ? OptionalLong.of(50L) : eip1559Denominator;
   }
 
@@ -68,95 +55,25 @@ public class JsonOptimismConfigOptions extends JsonGenesisConfigOptions implemen
    *
    * @return the EIP1559 denominatorCanyon
    */
+  @Override
   public OptionalLong getEIP1559DenominatorCanyon() {
     OptionalLong eip1559DenominatorCanyon =
-        JsonUtil.getLong(optimismConfigRoot, "eip1559denominatorcanyon");
+        JsonUtil.getLong(optimismConfigRoot, EIP1559_DENOMINATOR_CANYON);
     return eip1559DenominatorCanyon.isEmpty() ? OptionalLong.of(250L) : eip1559DenominatorCanyon;
   }
 
-  /**
-   * As map.
-   *
-   * @return the map
-   */
   @Override
   public Map<String, Object> asMap() {
     final ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
-    getChainId().ifPresent(chainId -> builder.put("chainId", chainId));
-
-    // mainnet fork blocks
-    getHomesteadBlockNumber().ifPresent(l -> builder.put("homesteadBlock", l));
-    getDaoForkBlock().ifPresent(l -> builder.put("daoForkBlock", l));
-    getTangerineWhistleBlockNumber().ifPresent(l -> builder.put("eip150Block", l));
-    getSpuriousDragonBlockNumber().ifPresent(l -> builder.put("eip158Block", l));
-    getByzantiumBlockNumber().ifPresent(l -> builder.put("byzantiumBlock", l));
-    getConstantinopleBlockNumber().ifPresent(l -> builder.put("constantinopleBlock", l));
-    getPetersburgBlockNumber().ifPresent(l -> builder.put("petersburgBlock", l));
-    getIstanbulBlockNumber().ifPresent(l -> builder.put("istanbulBlock", l));
-    getMuirGlacierBlockNumber().ifPresent(l -> builder.put("muirGlacierBlock", l));
-    getBerlinBlockNumber().ifPresent(l -> builder.put("berlinBlock", l));
-    getLondonBlockNumber().ifPresent(l -> builder.put("londonBlock", l));
-    getArrowGlacierBlockNumber().ifPresent(l -> builder.put("arrowGlacierBlock", l));
-    getGrayGlacierBlockNumber().ifPresent(l -> builder.put("grayGlacierBlock", l));
-    getMergeNetSplitBlockNumber().ifPresent(l -> builder.put("mergeNetSplitBlock", l));
-    getShanghaiTime().ifPresent(l -> builder.put("shanghaiTime", l));
-    getCancunTime().ifPresent(l -> builder.put("cancunTime", l));
-    getCancunEOFTime().ifPresent(l -> builder.put("cancunEOFTime", l));
-    getPragueTime().ifPresent(l -> builder.put("pragueTime", l));
-    getOsakaTime().ifPresent(l -> builder.put("osakaTime", l));
-    getTerminalBlockNumber().ifPresent(l -> builder.put("terminalBlockNumber", l));
-    getTerminalBlockHash().ifPresent(h -> builder.put("terminalBlockHash", h.toHexString()));
-    getFutureEipsTime().ifPresent(l -> builder.put("futureEipsTime", l));
-    getExperimentalEipsTime().ifPresent(l -> builder.put("experimentalEipsTime", l));
-
-    // classic fork blocks
-    getClassicForkBlock().ifPresent(l -> builder.put("classicForkBlock", l));
-    getEcip1015BlockNumber().ifPresent(l -> builder.put("ecip1015Block", l));
-    getDieHardBlockNumber().ifPresent(l -> builder.put("dieHardBlock", l));
-    getGothamBlockNumber().ifPresent(l -> builder.put("gothamBlock", l));
-    getDefuseDifficultyBombBlockNumber().ifPresent(l -> builder.put("ecip1041Block", l));
-    getAtlantisBlockNumber().ifPresent(l -> builder.put("atlantisBlock", l));
-    getAghartaBlockNumber().ifPresent(l -> builder.put("aghartaBlock", l));
-    getPhoenixBlockNumber().ifPresent(l -> builder.put("phoenixBlock", l));
-    getThanosBlockNumber().ifPresent(l -> builder.put("thanosBlock", l));
-    getMagnetoBlockNumber().ifPresent(l -> builder.put("magnetoBlock", l));
-    getMystiqueBlockNumber().ifPresent(l -> builder.put("mystiqueBlock", l));
-    getSpiralBlockNumber().ifPresent(l -> builder.put("spiralBlock", l));
-
-    getContractSizeLimit().ifPresent(l -> builder.put("contractSizeLimit", l));
-    getEvmStackSize().ifPresent(l -> builder.put("evmstacksize", l));
-    getEcip1017EraRounds().ifPresent(l -> builder.put("ecip1017EraRounds", l));
-
-    getWithdrawalRequestContractAddress()
-            .ifPresent(l -> builder.put("withdrawalRequestContractAddress", l));
-    getDepositContractAddress().ifPresent(l -> builder.put("depositContractAddress", l));
-    getConsolidationRequestContractAddress()
-            .ifPresent(l -> builder.put("consolidationRequestContractAddress", l));
-
-    if (isClique()) {
-      builder.put("clique", getCliqueConfigOptions().asMap());
+    if (optimismConfigRoot.has(EIP1559_ELASTICITY)) {
+      builder.put(EIP1559_ELASTICITY, getEIP1559Elasticity());
     }
-    if (isEthHash()) {
-      builder.put("ethash", getEthashConfigOptions().asMap());
+    if (optimismConfigRoot.has(EIP1559_DENOMINATOR)) {
+      builder.put(EIP1559_DENOMINATOR, getEIP1559Denominator());
     }
-    if (isIbft2()) {
-      builder.put("ibft2", getBftConfigOptions().asMap());
+    if (optimismConfigRoot.has(EIP1559_DENOMINATOR_CANYON)) {
+      builder.put(EIP1559_DENOMINATOR_CANYON, getEIP1559DenominatorCanyon());
     }
-    if (isQbft()) {
-      builder.put("qbft", getQbftConfigOptions().asMap());
-    }
-
-    if (isZeroBaseFee()) {
-      builder.put("zeroBaseFee", true);
-    }
-
-    if (isFixedBaseFee()) {
-      builder.put("fixedBaseFee", true);
-    }
-
-    getEIP1559Elasticity().ifPresent(l -> builder.put("eip1559Elasticity", l));
-    getEIP1559Denominator().ifPresent(l -> builder.put("eip1559Denominator", l));
-    getEIP1559DenominatorCanyon().ifPresent(l -> builder.put("eip1559DenominatorCanyon", l));
     return builder.build();
   }
 }

--- a/config/src/main/java/org/hyperledger/besu/config/JsonOptimismGenesisConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/JsonOptimismGenesisConfigOptions.java
@@ -20,6 +20,7 @@ import java.util.OptionalLong;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 
+/** Json impolementation of Optimism genesis config options. */
 public class JsonOptimismGenesisConfigOptions extends JsonGenesisConfigOptions
     implements OptimismGenesisConfigOptions {
 

--- a/config/src/main/java/org/hyperledger/besu/config/JsonOptimismGenesisConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/JsonOptimismGenesisConfigOptions.java
@@ -1,21 +1,35 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.hyperledger.besu.config;
+
+import java.util.Map;
+import java.util.OptionalLong;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 
-import java.util.Map;
-import java.util.Optional;
-import java.util.OptionalLong;
-
-public class JsonOptimismGenesisConfigOptions extends JsonGenesisConfigOptions implements OptimismGenesisConfigOptions {
+public class JsonOptimismGenesisConfigOptions extends JsonGenesisConfigOptions
+    implements OptimismGenesisConfigOptions {
 
   private static final String OPTIMISM_CONFIG_KEY = "optimism";
 
   /**
    * Instantiates a new Optimism genesis options.
    *
-   * @param maybeConfig       the optional config
-   * @param configOverrides   the config overrides map
+   * @param maybeConfig the optional config
+   * @param configOverrides the config overrides map
    * @param transitionsConfig the transitions configuration
    */
   JsonOptimismGenesisConfigOptions(
@@ -162,7 +176,6 @@ public class JsonOptimismGenesisConfigOptions extends JsonGenesisConfigOptions i
     }
     return false;
   }
-
 
   /**
    * As map.

--- a/config/src/main/java/org/hyperledger/besu/config/JsonOptimismGenesisConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/JsonOptimismGenesisConfigOptions.java
@@ -1,0 +1,248 @@
+package org.hyperledger.besu.config;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+public class JsonOptimismGenesisConfigOptions extends JsonGenesisConfigOptions implements OptimismGenesisConfigOptions {
+
+  private static final String OPTIMISM_CONFIG_KEY = "optimism";
+
+  /**
+   * Instantiates a new Optimism genesis options.
+   *
+   * @param maybeConfig       the optional config
+   * @param configOverrides   the config overrides map
+   * @param transitionsConfig the transitions configuration
+   */
+  JsonOptimismGenesisConfigOptions(
+      final ObjectNode maybeConfig,
+      final Map<String, String> configOverrides,
+      final TransitionsConfigOptions transitionsConfig) {
+    super(maybeConfig, configOverrides, transitionsConfig);
+  }
+
+  @Override
+  public boolean isOptimism() {
+    return configRoot.has(OPTIMISM_CONFIG_KEY);
+  }
+
+  @Override
+  public OptimismConfigOptions getOptimismConfigOptions() {
+    return JsonUtil.getObjectNode(configRoot, OPTIMISM_CONFIG_KEY)
+        .map(JsonOptimismConfigOptions::new)
+        .orElse(JsonOptimismConfigOptions.DEFAULT);
+  }
+
+  @Override
+  public OptionalLong getBedrockBlock() {
+    return getOptionalLong("bedrockblock");
+  }
+
+  @Override
+  public boolean isBedrockBlock(final long headBlock) {
+    OptionalLong bedrockBlock = getBedrockBlock();
+    if (bedrockBlock.isEmpty()) {
+      return false;
+    }
+    return bedrockBlock.getAsLong() <= headBlock;
+  }
+
+  @Override
+  public OptionalLong getRegolithTime() {
+    return getOptionalLong("regolithtime");
+  }
+
+  @Override
+  public boolean isRegolith(final long headTime) {
+    if (!isOptimism()) {
+      return false;
+    }
+    var regolithTime = getRegolithTime();
+    if (regolithTime.isPresent()) {
+      return regolithTime.getAsLong() <= headTime;
+    }
+    return false;
+  }
+
+  @Override
+  public OptionalLong getCanyonTime() {
+    return getOptionalLong("canyontime");
+  }
+
+  @Override
+  public boolean isCanyon(final long headTime) {
+    if (!isOptimism()) {
+      return false;
+    }
+    var canyonTime = getCanyonTime();
+    if (canyonTime.isPresent()) {
+      return canyonTime.getAsLong() <= headTime;
+    }
+    return false;
+  }
+
+  @Override
+  public OptionalLong getEcotoneTime() {
+    return getOptionalLong("ecotonetime");
+  }
+
+  @Override
+  public boolean isEcotone(final long headTime) {
+    if (!isOptimism()) {
+      return false;
+    }
+    var ecotoneTime = getEcotoneTime();
+    if (ecotoneTime.isPresent()) {
+      return ecotoneTime.getAsLong() <= headTime;
+    }
+    return false;
+  }
+
+  @Override
+  public OptionalLong getFjordTime() {
+    return getOptionalLong("fjordtime");
+  }
+
+  @Override
+  public boolean isFjord(final long headTime) {
+    if (!isOptimism()) {
+      return false;
+    }
+    var fjordTime = getFjordTime();
+    if (fjordTime.isPresent()) {
+      return fjordTime.getAsLong() <= headTime;
+    }
+    return false;
+  }
+
+  @Override
+  public OptionalLong getHoloceneTime() {
+    return OptionalLong.empty();
+  }
+
+  @Override
+  public boolean isHolocene(final long headTime) {
+    return false;
+  }
+
+  @Override
+  public OptionalLong getGraniteTime() {
+    return getOptionalLong("granitetime");
+  }
+
+  @Override
+  public boolean isGranite(final long headTime) {
+    if (!isOptimism()) {
+      return false;
+    }
+    var graniteTime = getGraniteTime();
+    if (graniteTime.isPresent()) {
+      return graniteTime.getAsLong() <= headTime;
+    }
+    return false;
+  }
+
+  @Override
+  public OptionalLong getInteropTime() {
+    return getOptionalLong("interoptime");
+  }
+
+  @Override
+  public boolean isInterop(final long headTime) {
+    if (!isOptimism()) {
+      return false;
+    }
+    var ecotoneTime = getEcotoneTime();
+    if (ecotoneTime.isPresent()) {
+      return ecotoneTime.getAsLong() <= headTime;
+    }
+    return false;
+  }
+
+
+  /**
+   * As map.
+   *
+   * @return the map
+   */
+  @Override
+  public Map<String, Object> asMap() {
+    final ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
+    getChainId().ifPresent(chainId -> builder.put("chainId", chainId));
+
+    // mainnet fork blocks
+    getHomesteadBlockNumber().ifPresent(l -> builder.put("homesteadBlock", l));
+    getDaoForkBlock().ifPresent(l -> builder.put("daoForkBlock", l));
+    getTangerineWhistleBlockNumber().ifPresent(l -> builder.put("eip150Block", l));
+    getSpuriousDragonBlockNumber().ifPresent(l -> builder.put("eip158Block", l));
+    getByzantiumBlockNumber().ifPresent(l -> builder.put("byzantiumBlock", l));
+    getConstantinopleBlockNumber().ifPresent(l -> builder.put("constantinopleBlock", l));
+    getPetersburgBlockNumber().ifPresent(l -> builder.put("petersburgBlock", l));
+    getIstanbulBlockNumber().ifPresent(l -> builder.put("istanbulBlock", l));
+    getMuirGlacierBlockNumber().ifPresent(l -> builder.put("muirGlacierBlock", l));
+    getBerlinBlockNumber().ifPresent(l -> builder.put("berlinBlock", l));
+    getLondonBlockNumber().ifPresent(l -> builder.put("londonBlock", l));
+    getArrowGlacierBlockNumber().ifPresent(l -> builder.put("arrowGlacierBlock", l));
+    getGrayGlacierBlockNumber().ifPresent(l -> builder.put("grayGlacierBlock", l));
+    getMergeNetSplitBlockNumber().ifPresent(l -> builder.put("mergeNetSplitBlock", l));
+    getShanghaiTime().ifPresent(l -> builder.put("shanghaiTime", l));
+    getCancunTime().ifPresent(l -> builder.put("cancunTime", l));
+    getCancunEOFTime().ifPresent(l -> builder.put("cancunEOFTime", l));
+    getPragueTime().ifPresent(l -> builder.put("pragueTime", l));
+    getOsakaTime().ifPresent(l -> builder.put("osakaTime", l));
+    getTerminalBlockNumber().ifPresent(l -> builder.put("terminalBlockNumber", l));
+    getTerminalBlockHash().ifPresent(h -> builder.put("terminalBlockHash", h.toHexString()));
+    getFutureEipsTime().ifPresent(l -> builder.put("futureEipsTime", l));
+    getExperimentalEipsTime().ifPresent(l -> builder.put("experimentalEipsTime", l));
+
+    // classic fork blocks
+    getClassicForkBlock().ifPresent(l -> builder.put("classicForkBlock", l));
+    getEcip1015BlockNumber().ifPresent(l -> builder.put("ecip1015Block", l));
+    getDieHardBlockNumber().ifPresent(l -> builder.put("dieHardBlock", l));
+    getGothamBlockNumber().ifPresent(l -> builder.put("gothamBlock", l));
+    getDefuseDifficultyBombBlockNumber().ifPresent(l -> builder.put("ecip1041Block", l));
+    getAtlantisBlockNumber().ifPresent(l -> builder.put("atlantisBlock", l));
+    getAghartaBlockNumber().ifPresent(l -> builder.put("aghartaBlock", l));
+    getPhoenixBlockNumber().ifPresent(l -> builder.put("phoenixBlock", l));
+    getThanosBlockNumber().ifPresent(l -> builder.put("thanosBlock", l));
+    getMagnetoBlockNumber().ifPresent(l -> builder.put("magnetoBlock", l));
+    getMystiqueBlockNumber().ifPresent(l -> builder.put("mystiqueBlock", l));
+    getSpiralBlockNumber().ifPresent(l -> builder.put("spiralBlock", l));
+
+    // optimism fork blocks
+    getBedrockBlock().ifPresent(l -> builder.put("bedrockBlock", l));
+    getRegolithTime().ifPresent(l -> builder.put("regolithTime", l));
+    getCanyonTime().ifPresent(l -> builder.put("canyonTime", l));
+    getEcotoneTime().ifPresent(l -> builder.put("ecotoneTime", l));
+    getFjordTime().ifPresent(l -> builder.put("fjordTime", l));
+    getHoloceneTime().ifPresent(l -> builder.put("holoceneTime", l));
+    getGraniteTime().ifPresent(l -> builder.put("graniteTime", l));
+    getInteropTime().ifPresent(l -> builder.put("interopTime", l));
+
+    getContractSizeLimit().ifPresent(l -> builder.put("contractSizeLimit", l));
+    getEvmStackSize().ifPresent(l -> builder.put("evmstacksize", l));
+    getEcip1017EraRounds().ifPresent(l -> builder.put("ecip1017EraRounds", l));
+
+    getWithdrawalRequestContractAddress()
+        .ifPresent(l -> builder.put("withdrawalRequestContractAddress", l));
+    getDepositContractAddress().ifPresent(l -> builder.put("depositContractAddress", l));
+    getConsolidationRequestContractAddress()
+        .ifPresent(l -> builder.put("consolidationRequestContractAddress", l));
+
+    if (isZeroBaseFee()) {
+      builder.put("zeroBaseFee", true);
+    }
+
+    if (isFixedBaseFee()) {
+      builder.put("fixedBaseFee", true);
+    }
+    if (isOptimism()) {
+      builder.put("optimism", getOptimismConfigOptions().asMap());
+    }
+    return builder.build();
+  }
+}

--- a/config/src/main/java/org/hyperledger/besu/config/OpGenesisConfigFile.java
+++ b/config/src/main/java/org/hyperledger/besu/config/OpGenesisConfigFile.java
@@ -8,7 +8,7 @@ import java.util.Map;
 
 public class OpGenesisConfigFile extends GenesisConfigFile {
 
-    OpGenesisConfigFile(GenesisReader loader) {
+    OpGenesisConfigFile(final GenesisReader loader) {
         super(loader);
     }
 
@@ -86,11 +86,11 @@ public class OpGenesisConfigFile extends GenesisConfigFile {
      * @return the config options
      */
     @Override
-    public JsonOptimismConfigOptions getConfigOptions() {
+    public JsonOptimismGenesisConfigOptions getConfigOptions() {
         final ObjectNode config = loader.getConfig();
         // are there any overrides to apply?
         if (this.overrides == null) {
-            return JsonOptimismConfigOptions.fromJsonObject(config);
+            return JsonOptimismGenesisConfigOptions.fromJsonObject(config);
         }
         // otherwise apply overrides
         Map<String, String> overridesRef = this.overrides;
@@ -103,6 +103,6 @@ public class OpGenesisConfigFile extends GenesisConfigFile {
             overridesRef.put("baseFeePerGas", optBaseFee.get().toShortHexString());
         }
 
-        return JsonOptimismConfigOptions.fromJsonObjectWithOverrides(config, overridesRef);
+        return JsonOptimismGenesisConfigOptions.fromJsonObjectWithOverrides(config, overridesRef);
     }
 }

--- a/config/src/main/java/org/hyperledger/besu/config/OpGenesisConfigFile.java
+++ b/config/src/main/java/org/hyperledger/besu/config/OpGenesisConfigFile.java
@@ -1,0 +1,108 @@
+package org.hyperledger.besu.config;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+public class OpGenesisConfigFile extends GenesisConfigFile {
+
+    OpGenesisConfigFile(GenesisReader loader) {
+        super(loader);
+    }
+
+    /**
+     * Mainnet genesis config file.
+     *
+     * @return the genesis config file
+     */
+    public static GenesisConfigFile mainnet() {
+        return fromSource(GenesisConfigFile.class.getResource("/optimism-mainnet.json"));
+    }
+
+    /**
+     * Genesis file from URL.
+     *
+     * @param jsonSource the URL
+     * @return the genesis config file
+     */
+    public static GenesisConfigFile fromSource(final URL jsonSource) {
+        return fromConfig(JsonUtil.objectNodeFromURL(jsonSource, false));
+    }
+
+    /**
+     * Genesis file from resource.
+     *
+     * @param resourceName the resource name
+     * @return the genesis config file
+     */
+    public static GenesisConfigFile fromResource(final String resourceName) {
+        return fromConfig(GenesisConfigFile.class.getResource(resourceName));
+    }
+
+    /**
+     * From config genesis config file.
+     *
+     * @param jsonSource the json string
+     * @return the genesis config file
+     */
+    public static OpGenesisConfigFile fromConfig(final URL jsonSource) {
+        return new OpGenesisConfigFile(new GenesisReader.FromURL(jsonSource));
+    }
+
+    /**
+     * From config genesis config file.
+     *
+     * @param json the json string
+     * @return the genesis config file
+     */
+    public static GenesisConfigFile fromConfig(final String json) {
+        return fromConfig(JsonUtil.objectNodeFromString(json, false));
+    }
+
+    /**
+     * From config genesis config file.
+     *
+     * @param config the config
+     * @return the genesis config file
+     */
+    public static GenesisConfigFile fromConfig(final ObjectNode config) {
+        return new GenesisConfigFile(new GenesisReader.FromObjectNode(config));
+    }
+
+    /**
+     * Gets parent hash.
+     *
+     * @return the parent hash
+     */
+    public String getStateHash() {
+        return JsonUtil.getString(genesisRoot, "statehash", "");
+    }
+
+    /**
+     * Gets config options, including any overrides.
+     *
+     * @return the config options
+     */
+    @Override
+    public JsonOptimismConfigOptions getConfigOptions() {
+        final ObjectNode config = loader.getConfig();
+        // are there any overrides to apply?
+        if (this.overrides == null) {
+            return JsonOptimismConfigOptions.fromJsonObject(config);
+        }
+        // otherwise apply overrides
+        Map<String, String> overridesRef = this.overrides;
+
+        // if baseFeePerGas has been explicitly configured, pass it as an override:
+        final var optBaseFee = getBaseFeePerGas();
+        if (optBaseFee.isPresent()) {
+            // streams and maps cannot handle null values.
+            overridesRef = new HashMap<>(this.overrides);
+            overridesRef.put("baseFeePerGas", optBaseFee.get().toShortHexString());
+        }
+
+        return JsonOptimismConfigOptions.fromJsonObjectWithOverrides(config, overridesRef);
+    }
+}

--- a/config/src/main/java/org/hyperledger/besu/config/OpGenesisConfigFile.java
+++ b/config/src/main/java/org/hyperledger/besu/config/OpGenesisConfigFile.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+/** Interface for Optimism genesis config file. */
 public class OpGenesisConfigFile extends GenesisConfigFile {
 
   OpGenesisConfigFile(final GenesisReader loader) {

--- a/config/src/main/java/org/hyperledger/besu/config/OpGenesisConfigFile.java
+++ b/config/src/main/java/org/hyperledger/besu/config/OpGenesisConfigFile.java
@@ -17,7 +17,7 @@ public class OpGenesisConfigFile extends GenesisConfigFile {
      *
      * @return the genesis config file
      */
-    public static GenesisConfigFile mainnet() {
+    public static OpGenesisConfigFile mainnet() {
         return fromSource(GenesisConfigFile.class.getResource("/optimism-mainnet.json"));
     }
 
@@ -27,7 +27,7 @@ public class OpGenesisConfigFile extends GenesisConfigFile {
      * @param jsonSource the URL
      * @return the genesis config file
      */
-    public static GenesisConfigFile fromSource(final URL jsonSource) {
+    public static OpGenesisConfigFile fromSource(final URL jsonSource) {
         return fromConfig(JsonUtil.objectNodeFromURL(jsonSource, false));
     }
 
@@ -37,7 +37,7 @@ public class OpGenesisConfigFile extends GenesisConfigFile {
      * @param resourceName the resource name
      * @return the genesis config file
      */
-    public static GenesisConfigFile fromResource(final String resourceName) {
+    public static OpGenesisConfigFile fromResource(final String resourceName) {
         return fromConfig(GenesisConfigFile.class.getResource(resourceName));
     }
 
@@ -57,7 +57,7 @@ public class OpGenesisConfigFile extends GenesisConfigFile {
      * @param json the json string
      * @return the genesis config file
      */
-    public static GenesisConfigFile fromConfig(final String json) {
+    public static OpGenesisConfigFile fromConfig(final String json) {
         return fromConfig(JsonUtil.objectNodeFromString(json, false));
     }
 
@@ -67,8 +67,8 @@ public class OpGenesisConfigFile extends GenesisConfigFile {
      * @param config the config
      * @return the genesis config file
      */
-    public static GenesisConfigFile fromConfig(final ObjectNode config) {
-        return new GenesisConfigFile(new GenesisReader.FromObjectNode(config));
+    public static OpGenesisConfigFile fromConfig(final ObjectNode config) {
+        return new OpGenesisConfigFile(new GenesisReader.FromObjectNode(config));
     }
 
     /**

--- a/config/src/main/java/org/hyperledger/besu/config/OpGenesisConfigFile.java
+++ b/config/src/main/java/org/hyperledger/besu/config/OpGenesisConfigFile.java
@@ -1,108 +1,122 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.hyperledger.besu.config;
-
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 public class OpGenesisConfigFile extends GenesisConfigFile {
 
-    OpGenesisConfigFile(final GenesisReader loader) {
-        super(loader);
+  OpGenesisConfigFile(final GenesisReader loader) {
+    super(loader);
+  }
+
+  /**
+   * Mainnet genesis config file.
+   *
+   * @return the genesis config file
+   */
+  public static OpGenesisConfigFile mainnet() {
+    return fromSource(GenesisConfigFile.class.getResource("/optimism-mainnet.json"));
+  }
+
+  /**
+   * Genesis file from URL.
+   *
+   * @param jsonSource the URL
+   * @return the genesis config file
+   */
+  public static OpGenesisConfigFile fromSource(final URL jsonSource) {
+    return fromConfig(JsonUtil.objectNodeFromURL(jsonSource, false));
+  }
+
+  /**
+   * Genesis file from resource.
+   *
+   * @param resourceName the resource name
+   * @return the genesis config file
+   */
+  public static OpGenesisConfigFile fromResource(final String resourceName) {
+    return fromConfig(GenesisConfigFile.class.getResource(resourceName));
+  }
+
+  /**
+   * From config genesis config file.
+   *
+   * @param jsonSource the json string
+   * @return the genesis config file
+   */
+  public static OpGenesisConfigFile fromConfig(final URL jsonSource) {
+    return new OpGenesisConfigFile(new GenesisReader.FromURL(jsonSource));
+  }
+
+  /**
+   * From config genesis config file.
+   *
+   * @param json the json string
+   * @return the genesis config file
+   */
+  public static OpGenesisConfigFile fromConfig(final String json) {
+    return fromConfig(JsonUtil.objectNodeFromString(json, false));
+  }
+
+  /**
+   * From config genesis config file.
+   *
+   * @param config the config
+   * @return the genesis config file
+   */
+  public static OpGenesisConfigFile fromConfig(final ObjectNode config) {
+    return new OpGenesisConfigFile(new GenesisReader.FromObjectNode(config));
+  }
+
+  /**
+   * Gets parent hash.
+   *
+   * @return the parent hash
+   */
+  public String getStateHash() {
+    return JsonUtil.getString(genesisRoot, "statehash", "");
+  }
+
+  /**
+   * Gets config options, including any overrides.
+   *
+   * @return the config options
+   */
+  @Override
+  public JsonOptimismGenesisConfigOptions getConfigOptions() {
+    final ObjectNode config = loader.getConfig();
+    // are there any overrides to apply?
+    if (this.overrides == null) {
+      return JsonOptimismGenesisConfigOptions.fromJsonObject(config);
+    }
+    // otherwise apply overrides
+    Map<String, String> overridesRef = this.overrides;
+
+    // if baseFeePerGas has been explicitly configured, pass it as an override:
+    final var optBaseFee = getBaseFeePerGas();
+    if (optBaseFee.isPresent()) {
+      // streams and maps cannot handle null values.
+      overridesRef = new HashMap<>(this.overrides);
+      overridesRef.put("baseFeePerGas", optBaseFee.get().toShortHexString());
     }
 
-    /**
-     * Mainnet genesis config file.
-     *
-     * @return the genesis config file
-     */
-    public static OpGenesisConfigFile mainnet() {
-        return fromSource(GenesisConfigFile.class.getResource("/optimism-mainnet.json"));
-    }
-
-    /**
-     * Genesis file from URL.
-     *
-     * @param jsonSource the URL
-     * @return the genesis config file
-     */
-    public static OpGenesisConfigFile fromSource(final URL jsonSource) {
-        return fromConfig(JsonUtil.objectNodeFromURL(jsonSource, false));
-    }
-
-    /**
-     * Genesis file from resource.
-     *
-     * @param resourceName the resource name
-     * @return the genesis config file
-     */
-    public static OpGenesisConfigFile fromResource(final String resourceName) {
-        return fromConfig(GenesisConfigFile.class.getResource(resourceName));
-    }
-
-    /**
-     * From config genesis config file.
-     *
-     * @param jsonSource the json string
-     * @return the genesis config file
-     */
-    public static OpGenesisConfigFile fromConfig(final URL jsonSource) {
-        return new OpGenesisConfigFile(new GenesisReader.FromURL(jsonSource));
-    }
-
-    /**
-     * From config genesis config file.
-     *
-     * @param json the json string
-     * @return the genesis config file
-     */
-    public static OpGenesisConfigFile fromConfig(final String json) {
-        return fromConfig(JsonUtil.objectNodeFromString(json, false));
-    }
-
-    /**
-     * From config genesis config file.
-     *
-     * @param config the config
-     * @return the genesis config file
-     */
-    public static OpGenesisConfigFile fromConfig(final ObjectNode config) {
-        return new OpGenesisConfigFile(new GenesisReader.FromObjectNode(config));
-    }
-
-    /**
-     * Gets parent hash.
-     *
-     * @return the parent hash
-     */
-    public String getStateHash() {
-        return JsonUtil.getString(genesisRoot, "statehash", "");
-    }
-
-    /**
-     * Gets config options, including any overrides.
-     *
-     * @return the config options
-     */
-    @Override
-    public JsonOptimismGenesisConfigOptions getConfigOptions() {
-        final ObjectNode config = loader.getConfig();
-        // are there any overrides to apply?
-        if (this.overrides == null) {
-            return JsonOptimismGenesisConfigOptions.fromJsonObject(config);
-        }
-        // otherwise apply overrides
-        Map<String, String> overridesRef = this.overrides;
-
-        // if baseFeePerGas has been explicitly configured, pass it as an override:
-        final var optBaseFee = getBaseFeePerGas();
-        if (optBaseFee.isPresent()) {
-            // streams and maps cannot handle null values.
-            overridesRef = new HashMap<>(this.overrides);
-            overridesRef.put("baseFeePerGas", optBaseFee.get().toShortHexString());
-        }
-
-        return JsonOptimismGenesisConfigOptions.fromJsonObjectWithOverrides(config, overridesRef);
-    }
+    return JsonOptimismGenesisConfigOptions.fromJsonObjectWithOverrides(config, overridesRef);
+  }
 }

--- a/config/src/main/java/org/hyperledger/besu/config/OptimismConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/OptimismConfigOptions.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.hyperledger.besu.config;
 
 import java.util.Map;

--- a/config/src/main/java/org/hyperledger/besu/config/OptimismConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/OptimismConfigOptions.java
@@ -1,0 +1,27 @@
+package org.hyperledger.besu.config;
+
+import java.util.OptionalLong;
+
+public interface OptimismConfigOptions {
+
+  /**
+   * Gets EIP1559 elasticity.
+   *
+   * @return the EIP1559 elasticity
+   */
+  OptionalLong getEIP1559Elasticity();
+
+  /**
+   * Gets EIP1559 denominator.
+   *
+   * @return the EIP1559 denominator
+   */
+  OptionalLong getEIP1559Denominator();
+
+  /**
+   * Gets EIP1559 denominatorCanyon.
+   *
+   * @return the EIP1559 denominatorCanyon
+   */
+  OptionalLong getEIP1559DenominatorCanyon();
+}

--- a/config/src/main/java/org/hyperledger/besu/config/OptimismConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/OptimismConfigOptions.java
@@ -1,5 +1,6 @@
 package org.hyperledger.besu.config;
 
+import java.util.Map;
 import java.util.OptionalLong;
 
 public interface OptimismConfigOptions {
@@ -24,4 +25,11 @@ public interface OptimismConfigOptions {
    * @return the EIP1559 denominatorCanyon
    */
   OptionalLong getEIP1559DenominatorCanyon();
+
+  /**
+   * As map.
+   *
+   * @return the map
+   */
+  Map<String, Object> asMap();
 }

--- a/config/src/main/java/org/hyperledger/besu/config/OptimismConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/OptimismConfigOptions.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.config;
 import java.util.Map;
 import java.util.OptionalLong;
 
+/** interface for Optimisim Config Options. */
 public interface OptimismConfigOptions {
 
   /**

--- a/config/src/main/java/org/hyperledger/besu/config/OptimismGenesisConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/OptimismGenesisConfigOptions.java
@@ -147,8 +147,8 @@ public interface OptimismGenesisConfigOptions extends GenesisConfigOptions {
 
   /**
    * Returns boolean indicating whether head time is interop or not.
-   * @param headTime epoch time to check
    *
+   * @param headTime epoch time to check
    * @return the optimism config options.
    */
   boolean isInterop(long headTime);

--- a/config/src/main/java/org/hyperledger/besu/config/OptimismGenesisConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/OptimismGenesisConfigOptions.java
@@ -1,0 +1,119 @@
+package org.hyperledger.besu.config;
+
+import java.util.OptionalLong;
+
+public interface OptimismGenesisConfigOptions extends GenesisConfigOptions {
+  /**
+   * Is Optimism boolean
+   *
+   * @return the boolean
+   */
+  boolean isOptimism();
+
+  /**
+   * Gets bedrock switch block number.
+   *
+   * @return the bedrock switch block number
+   */
+  OptionalLong getBedrockBlock();
+
+  /**
+   * Returns whether a fork scheduled at bedrock block number is active at the given head block
+   * number
+   *
+   * @param headBlock the head block height
+   * @return the boolean
+   */
+  boolean isBedrockBlock(long headBlock);
+
+  /**
+   * Gets regolith time.
+   *
+   * @return the regolith time
+   */
+  OptionalLong getRegolithTime();
+
+  /**
+   * Returns whether a fork scheduled at regolith timestamp is active at the given head timestamp.
+   *
+   * @param headTime the current head time
+   * @return the boolean
+   */
+  boolean isRegolith(long headTime);
+
+  /**
+   * Gets canyon time.
+   *
+   * @return the canyon time
+   */
+  OptionalLong getCanyonTime();
+
+  /**
+   * Returns whether a fork scheduled at canyon timestamp is active at the given head timestamp.
+   *
+   * @param headTime the current head time
+   * @return the boolean
+   */
+  boolean isCanyon(long headTime);
+
+  /**
+   * Gets ecotone time.
+   *
+   * @return the ecotone time
+   */
+  OptionalLong getEcotoneTime();
+
+  /**
+   * Returns whether a fork scheduled at ecotone timestamp is active at the given head timestamp.
+   *
+   * @param headTime the current head time
+   * @return the boolean
+   */
+  boolean isEcotone(long headTime);
+
+
+  /**
+   * Gets fjord time.
+   *
+   * @return the fjord time
+   */
+  OptionalLong getFjordTime();
+
+  /**
+   * Returns whether a fork scheduled at fjord timestamp is active at the given head timestamp.
+   *
+   * @param headTime the current head time
+   * @return the boolean
+   */
+  boolean isFjord(long headTime);
+
+  /**
+   * Gets Holocene time.
+   *
+   * @return the holocene time
+   */
+  OptionalLong getHoloceneTime();
+
+  /**
+   * Returns whether a fork scheduled at holocene timestamp is active at the given head timestamp.
+   *
+   * @param headTime the current head time
+   * @return the boolean
+   */
+  boolean isHolocene(long headTime);
+
+  /**
+   * Gets granite time.
+   *
+   * @return the granite time
+   */
+  OptionalLong getGraniteTime();
+
+  /**
+   * Returns whether a fork scheduled at granite timestamp is active at the given head timestamp.
+   *
+   * @param headTime the current head time
+   * @return the boolean
+   */
+  boolean isGranite(long headTime);
+}

--- a/config/src/main/java/org/hyperledger/besu/config/OptimismGenesisConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/OptimismGenesisConfigOptions.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.config;
 
 import java.util.OptionalLong;
 
+/** Optimism Genesis Config Options interface. */
 public interface OptimismGenesisConfigOptions extends GenesisConfigOptions {
   /**
    * Is Optimism boolean
@@ -137,7 +138,18 @@ public interface OptimismGenesisConfigOptions extends GenesisConfigOptions {
    */
   OptimismConfigOptions getOptimismConfigOptions();
 
+  /**
+   * Gets optimism interop time
+   *
+   * @return the optimism interop time.
+   */
   OptionalLong getInteropTime();
 
+  /**
+   * Returns boolean indicating whether head time is interop or not.
+   * @param headTime epoch time to check
+   *
+   * @return the optimism config options.
+   */
   boolean isInterop(long headTime);
 }

--- a/config/src/main/java/org/hyperledger/besu/config/OptimismGenesisConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/OptimismGenesisConfigOptions.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.hyperledger.besu.config;
 
 import java.util.OptionalLong;
@@ -70,7 +84,6 @@ public interface OptimismGenesisConfigOptions extends GenesisConfigOptions {
    * @return the boolean
    */
   boolean isEcotone(long headTime);
-
 
   /**
    * Gets fjord time.

--- a/config/src/main/java/org/hyperledger/besu/config/OptimismGenesisConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/OptimismGenesisConfigOptions.java
@@ -116,4 +116,15 @@ public interface OptimismGenesisConfigOptions extends GenesisConfigOptions {
    * @return the boolean
    */
   boolean isGranite(long headTime);
+
+  /**
+   * Gets optimism config options
+   *
+   * @return the optimism config options.
+   */
+  OptimismConfigOptions getOptimismConfigOptions();
+
+  OptionalLong getInteropTime();
+
+  boolean isInterop(long headTime);
 }

--- a/config/src/main/resources/optimism-mainnet.json
+++ b/config/src/main/resources/optimism-mainnet.json
@@ -1,0 +1,53 @@
+{
+  "config": {
+    "chainId": 10,
+    "homesteadBlock": 0,
+    "eip150Block": 0,
+    "eip155Block": 0,
+    "eip158Block": 0,
+    "byzantiumBlock": 0,
+    "constantinopleBlock": 0,
+    "petersburgBlock": 0,
+    "istanbulBlock": 0,
+    "muirGlacierBlock": 0,
+    "berlinBlock": 3950000,
+    "londonBlock": 105235063,
+    "arrowGlacierBlock": 105235063,
+    "grayGlacierBlock": 105235063,
+    "mergeNetsplitBlock": 105235063,
+    "shanghaiTime": 1704992401,
+    "cancunTime": 1710374401,
+    "bedrockBlock": 105235063,
+    "regolithTime": 0,
+    "canyonTime": 1704992401,
+    "ecotoneTime": 1710374401,
+    "fjordTime": 1720627201,
+    "terminalTotalDifficulty": 0,
+    "terminalTotalDifficultyPassed": true,
+    "optimism": {
+      "eip1559Elasticity": 6,
+      "eip1559Denominator": 50,
+      "eip1559DenominatorCanyon": 250
+    },
+    "discovery": {
+      "bootnodes": [
+        "enode://d860a01f9722d78051619d1e2351aba3f43f943f6f00718d1b9baa4101932a1f5011f16bb2b1bb35db20d6fe28fa0bf09636d26a87d31de9ec6203eeedb1f666@18.138.108.67:30303",
+        "enode://22a8232c3abc76a16ae9d6c3b164f98775fe226f0917b0ca871128a74a8e9630b458460865bab457221f1d448dd9791d24c4e5d88786180ac185df813a68d4de@3.209.45.79:30303",
+        "enode://2b252ab6a1d0f971d9722cb839a42cb81db019ba44c08754628ab4a823487071b5695317c8ccd085219c3a03af063495b2f1da8d18218da2d6a82981b45e6ffc@65.108.70.101:30303",
+        "enode://4aeb4ab6c14b23e2c4cfdce879c04b0748a20d8e9b59e25ded2a08143e265c6c25936e74cbc8e641e3312ca288673d91f2f93f8e277de3cfa444ecdaaf982052@157.90.35.166:30303"
+      ]
+    }
+  },
+  "nonce": "0x0",
+  "timestamp": "0x0",
+  "extraData": "0x000000000000000000000000000000000000000000000000000000000000000000000398232e2064f896018496b4b44b3d62751f0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+  "gasLimit": "0xe4e1c0",
+  "difficulty": "0x1",
+  "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "coinbase": "0x0000000000000000000000000000000000000000",
+  "alloc": {},
+  "number": "0x0",
+  "gasUsed": "0x0",
+  "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "stateHash": "0xeddb4c1786789419153a27c4c80ff44a2226b6eda04f7e22ce5bae892ea568eb"
+}

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/GenesisState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/GenesisState.java
@@ -50,12 +50,12 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt64;
 
-public final class GenesisState {
+public class GenesisState {
 
-  private final Block block;
-  private final GenesisConfigFile genesisConfigFile;
+  protected final Block block;
+  protected final GenesisConfigFile genesisConfigFile;
 
-  private GenesisState(final Block block, final GenesisConfigFile genesisConfigFile) {
+  GenesisState(final Block block, final GenesisConfigFile genesisConfigFile) {
     this.block = block;
     this.genesisConfigFile = genesisConfigFile;
   }
@@ -142,7 +142,7 @@ public final class GenesisState {
     return new GenesisState(block, genesisConfigFile);
   }
 
-  private static BlockBody buildBody(final GenesisConfigFile config) {
+  static BlockBody buildBody(final GenesisConfigFile config) {
     final Optional<List<Withdrawal>> withdrawals =
         isShanghaiAtGenesis(config) ? Optional.of(emptyList()) : Optional.empty();
 
@@ -179,7 +179,7 @@ public final class GenesisState {
     target.persist(rootHeader);
   }
 
-  private static Hash calculateGenesisStateRoot(
+  static Hash calculateGenesisStateRoot(
       final DataStorageConfiguration dataStorageConfiguration,
       final GenesisConfigFile genesisConfigFile) {
     try (var worldState = createGenesisWorldState(dataStorageConfiguration)) {
@@ -190,7 +190,7 @@ public final class GenesisState {
     }
   }
 
-  private static BlockHeader buildHeader(
+  static BlockHeader buildHeader(
       final GenesisConfigFile genesis,
       final Hash genesisRootHash,
       final ProtocolSchedule protocolSchedule) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/OptimismGenesisState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/OptimismGenesisState.java
@@ -1,6 +1,19 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.hyperledger.besu.ethereum.chain;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.hyperledger.besu.config.GenesisConfigFile;
 import org.hyperledger.besu.config.OpGenesisConfigFile;
 import org.hyperledger.besu.datatypes.Hash;
@@ -10,10 +23,12 @@ import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
 
 import java.net.URL;
 
+import com.google.common.annotations.VisibleForTesting;
+
 public class OptimismGenesisState extends GenesisState {
 
   OptimismGenesisState(final Block block, final GenesisConfigFile genesisConfigFile) {
-      super(block, genesisConfigFile);
+    super(block, genesisConfigFile);
   }
 
   /**
@@ -23,7 +38,8 @@ public class OptimismGenesisState extends GenesisState {
    * @param protocolSchedule A protocol Schedule associated with
    * @return A new {@link GenesisState}.
    */
-  public static OptimismGenesisState fromJson(final String json, final ProtocolSchedule protocolSchedule) {
+  public static OptimismGenesisState fromJson(
+      final String json, final ProtocolSchedule protocolSchedule) {
     return fromConfig(OpGenesisConfigFile.fromConfig(json), protocolSchedule);
   }
 
@@ -54,7 +70,8 @@ public class OptimismGenesisState extends GenesisState {
    */
   public static OptimismGenesisState fromConfig(
       final OpGenesisConfigFile config, final ProtocolSchedule protocolSchedule) {
-    return OptimismGenesisState.fromConfig(DataStorageConfiguration.DEFAULT_CONFIG, config, protocolSchedule);
+    return OptimismGenesisState.fromConfig(
+        DataStorageConfiguration.DEFAULT_CONFIG, config, protocolSchedule);
   }
 
   /**
@@ -72,11 +89,13 @@ public class OptimismGenesisState extends GenesisState {
       final ProtocolSchedule protocolSchedule) {
     // for optimism mainnet, it will modify genesis state root.
     final Hash genesisStateRoot;
-    if (!genesisConfigFile.getStateHash().isEmpty() && genesisConfigFile.streamAllocations().findAny().isEmpty()) {
+    if (!genesisConfigFile.getStateHash().isEmpty()
+        && genesisConfigFile.streamAllocations().findAny().isEmpty()) {
       genesisStateRoot = Hash.fromHexStringLenient(genesisConfigFile.getStateHash());
     } else {
       // other optimism network, it will calculate genesis state root.
-      genesisStateRoot = GenesisState.calculateGenesisStateRoot(dataStorageConfiguration, genesisConfigFile);
+      genesisStateRoot =
+          GenesisState.calculateGenesisStateRoot(dataStorageConfiguration, genesisConfigFile);
     }
     final Block block =
         new Block(
@@ -84,5 +103,4 @@ public class OptimismGenesisState extends GenesisState {
             GenesisState.buildBody(genesisConfigFile));
     return new OptimismGenesisState(block, genesisConfigFile);
   }
-
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/OptimismGenesisState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/OptimismGenesisState.java
@@ -22,7 +22,7 @@ public class OptimismGenesisState extends GenesisState {
    * @param protocolSchedule A protocol Schedule associated with
    * @return A new {@link GenesisState}.
    */
-  public static GenesisState fromConfig(
+  public static OptimismGenesisState fromConfig(
       final DataStorageConfiguration dataStorageConfiguration,
       final OpGenesisConfigFile genesisConfigFile,
       final ProtocolSchedule protocolSchedule) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/OptimismGenesisState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/OptimismGenesisState.java
@@ -1,0 +1,44 @@
+package org.hyperledger.besu.ethereum.chain;
+
+import org.hyperledger.besu.config.GenesisConfigFile;
+import org.hyperledger.besu.config.OpGenesisConfigFile;
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
+
+public class OptimismGenesisState extends GenesisState {
+
+  OptimismGenesisState(final Block block, final GenesisConfigFile genesisConfigFile) {
+      super(block, genesisConfigFile);
+  }
+
+  /**
+   * Construct a {@link GenesisState} from a JSON object for Optimism.
+   *
+   * @param dataStorageConfiguration A {@link DataStorageConfiguration} describing the storage
+   *     configuration
+   * @param genesisConfigFile A {@link GenesisConfigFile} describing the genesis block.
+   * @param protocolSchedule A protocol Schedule associated with
+   * @return A new {@link GenesisState}.
+   */
+  public static GenesisState fromConfig(
+      final DataStorageConfiguration dataStorageConfiguration,
+      final OpGenesisConfigFile genesisConfigFile,
+      final ProtocolSchedule protocolSchedule) {
+    // for optimism mainnet, it will modify genesis state root.
+    final Hash genesisStateRoot;
+    if (!genesisConfigFile.getStateHash().isEmpty() && genesisConfigFile.streamAllocations().findAny().isEmpty()) {
+      genesisStateRoot = Hash.fromHexStringLenient(genesisConfigFile.getStateHash());
+    } else {
+      // other optimism network, it will calculate genesis state root.
+      genesisStateRoot = GenesisState.calculateGenesisStateRoot(dataStorageConfiguration, genesisConfigFile);
+    }
+    final Block block =
+        new Block(
+            GenesisState.buildHeader(genesisConfigFile, genesisStateRoot, protocolSchedule),
+            GenesisState.buildBody(genesisConfigFile));
+    return new OptimismGenesisState(block, genesisConfigFile);
+  }
+
+}

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/OptimismGenesisState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/OptimismGenesisState.java
@@ -1,5 +1,6 @@
 package org.hyperledger.besu.ethereum.chain;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.hyperledger.besu.config.GenesisConfigFile;
 import org.hyperledger.besu.config.OpGenesisConfigFile;
 import org.hyperledger.besu.datatypes.Hash;
@@ -7,10 +8,53 @@ import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
 
+import java.net.URL;
+
 public class OptimismGenesisState extends GenesisState {
 
   OptimismGenesisState(final Block block, final GenesisConfigFile genesisConfigFile) {
       super(block, genesisConfigFile);
+  }
+
+  /**
+   * Construct a {@link GenesisState} from a JSON string.
+   *
+   * @param json A JSON string describing the genesis block
+   * @param protocolSchedule A protocol Schedule associated with
+   * @return A new {@link GenesisState}.
+   */
+  public static OptimismGenesisState fromJson(final String json, final ProtocolSchedule protocolSchedule) {
+    return fromConfig(OpGenesisConfigFile.fromConfig(json), protocolSchedule);
+  }
+
+  /**
+   * Construct a {@link GenesisState} from a URL
+   *
+   * @param dataStorageConfiguration A {@link DataStorageConfiguration} describing the storage
+   *     configuration
+   * @param jsonSource A URL pointing to JSON genesis file
+   * @param protocolSchedule A protocol Schedule associated with
+   * @return A new {@link GenesisState}.
+   */
+  @VisibleForTesting
+  static GenesisState fromJsonSource(
+      final DataStorageConfiguration dataStorageConfiguration,
+      final URL jsonSource,
+      final ProtocolSchedule protocolSchedule) {
+    return fromConfig(
+        dataStorageConfiguration, OpGenesisConfigFile.fromConfig(jsonSource), protocolSchedule);
+  }
+
+  /**
+   * Construct a {@link GenesisState} from a genesis file object.
+   *
+   * @param config A {@link OptimismGenesisState} describing the genesis block.
+   * @param protocolSchedule A protocol Schedule associated with
+   * @return A new {@link GenesisState}.
+   */
+  public static OptimismGenesisState fromConfig(
+      final OpGenesisConfigFile config, final ProtocolSchedule protocolSchedule) {
+    return OptimismGenesisState.fromConfig(DataStorageConfiguration.DEFAULT_CONFIG, config, protocolSchedule);
   }
 
   /**


### PR DESCRIPTION
In [op-geth/core/genesis.go#L489-L502](https://github.com/ethereum-optimism/op-geth/blob/efa05b1bf5c22a60745e638ad9d4adadfe3daba9/core/genesis.go#L489-L502):
```
func (g *Genesis) ToBlock() *types.Block {
	var root common.Hash
	var err error
	if g.StateHash != nil {
		if len(g.Alloc) > 0 {
			panic(fmt.Errorf("cannot both have genesis hash %s "+
				"and non-empty state-allocation", *g.StateHash))
		}
		root = *g.StateHash
	} else if root, err = hashAlloc(&g.Alloc, g.IsVerkle()); err != nil {
		panic(err)
	}
	return g.toBlockWithRoot(root)
}
```
It will first check whether the stateHash value is specified in the genesis file.

But the allocs must be emtpy.

The stateHash on the Optimism mainnet is set to 0xeddb4c1786789419153a27c4c80ff44a2226b6eda04f7e22ce5bae892ea568eb.

On the Optimism Sepolia network, the stateHash is calculated based on the alloc.